### PR TITLE
Adding export of files in case of Error Task

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
     <description>Service responsible of exporting gridcapa outputs when available to an FTP server.</description>
 
     <properties>
-        <task-manager.version>1.2.0</task-manager.version>
+        <task-manager.version>1.12.0</task-manager.version>
         <apache-common-net.version>3.8.0</apache-common-net.version>
         <mock-ftp-server.version>2.7.1</mock-ftp-server.version>
         <logstash.version>4.9</logstash.version>

--- a/src/main/java/com/farao_community/farao/gridcapa/export/GridcapaExportService.java
+++ b/src/main/java/com/farao_community/farao/gridcapa/export/GridcapaExportService.java
@@ -65,8 +65,8 @@ public class GridcapaExportService {
 
     void exportOutputsForTask(TaskDto taskDto) {
         MDC.put("gridcapa-task-id", taskDto.getId().toString());
-        boolean taskWithOutputs = taskDto.getStatus().equals(TaskStatus.SUCCESS) || taskDto.getStatus().equals(TaskStatus.ERROR);
-        if (taskWithOutputs) {
+        boolean isTaskFinished = taskDto.getStatus().equals(TaskStatus.SUCCESS) || taskDto.getStatus().equals(TaskStatus.ERROR);
+        if (isTaskFinished) {
             LOGGER.info("Received a task status {} event for timestamp: {}, trying to export result within the configured interval.", taskDto.getStatus(), taskDto.getTimestamp());
             fetchOutputsAvailable(taskDto);
             exportValidatedOutputsAndLog(taskDto);
@@ -100,8 +100,10 @@ public class GridcapaExportService {
         }
     }
 
+    /**
+     * Sometimes the files are not validated immediately with task status update, we retry to fetch task
+     */
     private void fetchOutputsAvailable(TaskDto taskDto) {
-        //Sometimes the files are not validated immediately with task status update
         boolean allOutputsAvailable = checkAllOutputFileValidated(taskDto);
         int retryCounter = 0;
         while (retryCounter < fetchTaskRetriesNumber && !allOutputsAvailable) {

--- a/src/main/java/com/farao_community/farao/gridcapa/export/GridcapaExportService.java
+++ b/src/main/java/com/farao_community/farao/gridcapa/export/GridcapaExportService.java
@@ -74,6 +74,7 @@ public class GridcapaExportService {
     }
 
     private void exportValidatedOutputsAndLog(TaskDto taskDto) {
+        businessLogger.info("Task status {}, exporting results for timestamp: {}", taskDto.getStatus(), taskDto.getTimestamp());
         if (seperateOutputFiles) {
             taskDto.getOutputs().stream().filter(processFileDto -> processFileDto.getProcessFileStatus().equals(ProcessFileStatus.VALIDATED))
                     .forEach(processFileDto -> {

--- a/src/test/java/com/farao_community/farao/gridcapa/export/GridcapaExportServiceTest.java
+++ b/src/test/java/com/farao_community/farao/gridcapa/export/GridcapaExportServiceTest.java
@@ -56,7 +56,7 @@ class GridcapaExportServiceTest {
         TaskDto taskDto = new TaskDto(UUID.fromString("1fdda469-53e9-4d63-a533-b935cffdd2f6"), OffsetDateTime.parse("2022-04-27T10:10Z"), TaskStatus.SUCCESS, new ArrayList<>(), new ArrayList<>(), createProcessFileList(2, 2), new ArrayList<>());
         Mockito.when(restTemplate.getForEntity("http://localhost:8080/tasks/2022-04-27T10:10Z/outputs", byte[].class)).thenReturn(ResponseEntity.ok("test".getBytes(StandardCharsets.UTF_8)));
         Mockito.when(restTemplate.getForEntity("http://localhost:8080/tasks/2022-04-27T10:10Z", TaskDto.class)).thenReturn(ResponseEntity.of(Optional.of(taskDto)));
-        outputsToFtpService.exportOutputsForSuccessfulTasks(taskDto);
+        outputsToFtpService.exportOutputsForTask(taskDto);
         Mockito.verify(restTemplate, Mockito.atLeastOnce()).getForEntity("http://localhost:8080/tasks/2022-04-27T10:10Z/outputs", byte[].class);
     }
 
@@ -66,7 +66,7 @@ class GridcapaExportServiceTest {
         TaskDto taskDto = new TaskDto(UUID.fromString("1fdda469-53e9-4d63-a533-b935cffdd2f6"), OffsetDateTime.parse("2022-04-27T10:11Z"), TaskStatus.SUCCESS, new ArrayList<>(), new ArrayList<>(), createProcessFileList(2, 1), new ArrayList<>());
         Mockito.when(restTemplate.getForEntity("http://localhost:8080/tasks/2022-04-27T10:11Z/outputs", byte[].class)).thenReturn(ResponseEntity.ok("test".getBytes(StandardCharsets.UTF_8)));
         Mockito.when(restTemplate.getForEntity("http://localhost:8080/tasks/2022-04-27T10:11Z", TaskDto.class)).thenReturn(ResponseEntity.of(Optional.of(taskDto)));
-        outputsToFtpService.exportOutputsForSuccessfulTasks(taskDto);
+        outputsToFtpService.exportOutputsForTask(taskDto);
         Mockito.verify(restTemplate, Mockito.times(1)).getForEntity("http://localhost:8080/tasks/2022-04-27T10:11Z/outputs", byte[].class);
     }
 
@@ -76,7 +76,17 @@ class GridcapaExportServiceTest {
         TaskDto taskDto = new TaskDto(UUID.fromString("1fdda469-53e9-4d63-a533-b935cffdd2f6"), OffsetDateTime.parse("2022-04-27T10:11Z"), TaskStatus.ERROR, new ArrayList<>(), new ArrayList<>(), createProcessFileList(2, 1), new ArrayList<>());
         Mockito.when(restTemplate.getForEntity("http://localhost:8080/tasks/2022-04-27T10:11Z/outputs", byte[].class)).thenReturn(ResponseEntity.ok("test".getBytes(StandardCharsets.UTF_8)));
         Mockito.when(restTemplate.getForEntity("http://localhost:8080/tasks/2022-04-27T10:11Z", TaskDto.class)).thenReturn(ResponseEntity.of(Optional.of(taskDto)));
-        outputsToFtpService.exportOutputsForSuccessfulTasks(taskDto);
+        outputsToFtpService.exportOutputsForTask(taskDto);
+        Mockito.verify(restTemplate, Mockito.times(1)).getForEntity("http://localhost:8080/tasks/2022-04-27T10:11Z/outputs", byte[].class);
+    }
+
+    @Test
+    void checkTaskManagerCallWithLogFileForErrorTask() {
+        ReflectionTestUtils.setField(outputsToFtpService, "seperateOutputFiles", false);
+        TaskDto taskDto = new TaskDto(UUID.fromString("1fdda469-53e9-4d63-a533-b935cffdd2f6"), OffsetDateTime.parse("2022-04-27T10:11Z"), TaskStatus.ERROR, new ArrayList<>(), new ArrayList<>(), createProcessFileList(2, 0), new ArrayList<>());
+        Mockito.when(restTemplate.getForEntity("http://localhost:8080/tasks/2022-04-27T10:11Z/outputs", byte[].class)).thenReturn(ResponseEntity.ok("test".getBytes(StandardCharsets.UTF_8)));
+        Mockito.when(restTemplate.getForEntity("http://localhost:8080/tasks/2022-04-27T10:11Z", TaskDto.class)).thenReturn(ResponseEntity.of(Optional.of(taskDto)));
+        outputsToFtpService.exportOutputsForTask(taskDto);
         Mockito.verify(restTemplate, Mockito.times(1)).getForEntity("http://localhost:8080/tasks/2022-04-27T10:11Z/outputs", byte[].class);
     }
 
@@ -85,7 +95,7 @@ class GridcapaExportServiceTest {
         TaskDto taskDto = new TaskDto(UUID.fromString("1fdda469-53e9-4d63-a533-b935cffdd2f6"), OffsetDateTime.parse("2022-04-27T10:11Z"), TaskStatus.ERROR, new ArrayList<>(), new ArrayList<>(), createProcessFileList(2, 0), new ArrayList<>());
         Mockito.when(restTemplate.getForEntity("http://localhost:8080/tasks/2022-04-27T10:11Z/outputs", byte[].class)).thenReturn(ResponseEntity.ok("test".getBytes(StandardCharsets.UTF_8)));
         Mockito.when(restTemplate.getForEntity("http://localhost:8080/tasks/2022-04-27T10:11Z", TaskDto.class)).thenReturn(ResponseEntity.of(Optional.of(taskDto)));
-        outputsToFtpService.exportOutputsForSuccessfulTasks(taskDto);
+        outputsToFtpService.exportOutputsForTask(taskDto);
         Mockito.verify(restTemplate, Mockito.never()).getForEntity("http://localhost:8080/tasks/2022-04-27T10:11Z/outputs", byte[].class);
     }
 
@@ -98,7 +108,7 @@ class GridcapaExportServiceTest {
         Mockito.when(restTemplate.getForEntity("http://localhost:8080/tasks/2022-04-27T10:10Z/file/AA2", byte[].class)).thenReturn(ResponseEntity.ok("test3".getBytes(StandardCharsets.UTF_8)));
         Mockito.when(restTemplate.getForEntity("http://localhost:8080/tasks/2022-04-27T10:10Z/file/LOGS", byte[].class)).thenReturn(ResponseEntity.ok("rao-logs.zip".getBytes(StandardCharsets.UTF_8)));
         Mockito.when(restTemplate.getForEntity("http://localhost:8080/tasks/2022-04-27T10:10Z", TaskDto.class)).thenReturn(ResponseEntity.of(Optional.of(taskDto)));
-        outputsToFtpService.exportOutputsForSuccessfulTasks(taskDto);
+        outputsToFtpService.exportOutputsForTask(taskDto);
         Mockito.verify(restTemplate, Mockito.atLeastOnce()).getForEntity("http://localhost:8080/tasks/2022-04-27T10:10Z/file/AA0", byte[].class);
         Mockito.verify(restTemplate, Mockito.atLeastOnce()).getForEntity("http://localhost:8080/tasks/2022-04-27T10:10Z/file/AA1", byte[].class);
         Mockito.verify(restTemplate, Mockito.atLeastOnce()).getForEntity("http://localhost:8080/tasks/2022-04-27T10:10Z/file/AA2", byte[].class);
@@ -111,20 +121,16 @@ class GridcapaExportServiceTest {
     }
 
     @Test
-    void checkTaskManagerCallForSeperateZipFilesForInterruptedTask() {
+    void checkTaskManagerCallForLogsForErrorTask() {
         ReflectionTestUtils.setField(outputsToFtpService, "seperateOutputFiles", true);
-        TaskDto taskDto = new TaskDto(UUID.fromString("1fdda469-53e9-4d63-a533-b935cffdd2f6"), OffsetDateTime.parse("2022-04-27T10:10Z"), TaskStatus.INTERRUPTED, new ArrayList<>(), new ArrayList<>(), createProcessFileList(3, 1), new ArrayList<>());
-        Mockito.when(restTemplate.getForEntity("http://localhost:8080/tasks/2022-04-27T10:10Z/file/AA0", byte[].class)).thenReturn(ResponseEntity.ok("test1".getBytes(StandardCharsets.UTF_8)));
-        Mockito.when(restTemplate.getForEntity("http://localhost:8080/tasks/2022-04-27T10:10Z/file/AA1", byte[].class)).thenReturn(ResponseEntity.ok("test2".getBytes(StandardCharsets.UTF_8)));
-        Mockito.when(restTemplate.getForEntity("http://localhost:8080/tasks/2022-04-27T10:10Z/file/AA2", byte[].class)).thenReturn(ResponseEntity.ok("test3".getBytes(StandardCharsets.UTF_8)));
+        TaskDto taskDto = new TaskDto(UUID.fromString("1fdda469-53e9-4d63-a533-b935cffdd2f6"), OffsetDateTime.parse("2022-04-27T10:10Z"), TaskStatus.ERROR, new ArrayList<>(), new ArrayList<>(), createProcessFileList(3, 0), new ArrayList<>());
         Mockito.when(restTemplate.getForEntity("http://localhost:8080/tasks/2022-04-27T10:10Z/file/LOGS", byte[].class)).thenReturn(ResponseEntity.ok("rao-logs.zip".getBytes(StandardCharsets.UTF_8)));
         Mockito.when(restTemplate.getForEntity("http://localhost:8080/tasks/2022-04-27T10:10Z", TaskDto.class)).thenReturn(ResponseEntity.of(Optional.of(taskDto)));
-        outputsToFtpService.exportOutputsForSuccessfulTasks(taskDto);
-        Mockito.verify(restTemplate, Mockito.atLeastOnce()).getForEntity("http://localhost:8080/tasks/2022-04-27T10:10Z/file/AA0", byte[].class);
-        Mockito.verify(restTemplate, Mockito.never()).getForEntity("http://localhost:8080/tasks/2022-04-27T10:10Z/file/AA1", byte[].class);
+        outputsToFtpService.exportOutputsForTask(taskDto);
+        Mockito.verify(restTemplate, Mockito.never()).getForEntity("http://localhost:8080/tasks/2022-04-27T10:10Z/file/AA0", byte[].class);
         Mockito.verify(restTemplate, Mockito.atLeastOnce()).getForEntity("http://localhost:8080/tasks/2022-04-27T10:10Z/file/LOGS", byte[].class);
         try {
-            Mockito.verify(ftpClientAdapter, Mockito.times(2)).upload(Mockito.anyString(), Mockito.any());
+            Mockito.verify(ftpClientAdapter, Mockito.times(1)).upload(Mockito.anyString(), Mockito.any());
         } catch (IOException e) {
             Assertions.fail("checkTaskManagerCallForSeperateZipFiles : ftpClientAdapter should not throw IOException!");
         }

--- a/src/test/java/com/farao_community/farao/gridcapa/export/GridcapaExportServiceTest.java
+++ b/src/test/java/com/farao_community/farao/gridcapa/export/GridcapaExportServiceTest.java
@@ -51,7 +51,8 @@ class GridcapaExportServiceTest {
     }
 
     @Test
-    void checkTaskManagerCall() {
+    void checkTaskManagerCallWithAllOutputsForSuccessTask() {
+        ReflectionTestUtils.setField(outputsToFtpService, "seperateOutputFiles", false);
         TaskDto taskDto = new TaskDto(UUID.fromString("1fdda469-53e9-4d63-a533-b935cffdd2f6"), OffsetDateTime.parse("2022-04-27T10:10Z"), TaskStatus.SUCCESS, new ArrayList<>(), new ArrayList<>(), createProcessFileList(2, 2), new ArrayList<>());
         Mockito.when(restTemplate.getForEntity("http://localhost:8080/tasks/2022-04-27T10:10Z/outputs", byte[].class)).thenReturn(ResponseEntity.ok("test".getBytes(StandardCharsets.UTF_8)));
         Mockito.when(restTemplate.getForEntity("http://localhost:8080/tasks/2022-04-27T10:10Z", TaskDto.class)).thenReturn(ResponseEntity.of(Optional.of(taskDto)));
@@ -60,8 +61,28 @@ class GridcapaExportServiceTest {
     }
 
     @Test
-    void checkTaskManagerCallMissingFile() {
+    void checkTaskManagerCallWithMissingFileForSuccessTask() {
+        ReflectionTestUtils.setField(outputsToFtpService, "seperateOutputFiles", false);
         TaskDto taskDto = new TaskDto(UUID.fromString("1fdda469-53e9-4d63-a533-b935cffdd2f6"), OffsetDateTime.parse("2022-04-27T10:11Z"), TaskStatus.SUCCESS, new ArrayList<>(), new ArrayList<>(), createProcessFileList(2, 1), new ArrayList<>());
+        Mockito.when(restTemplate.getForEntity("http://localhost:8080/tasks/2022-04-27T10:11Z/outputs", byte[].class)).thenReturn(ResponseEntity.ok("test".getBytes(StandardCharsets.UTF_8)));
+        Mockito.when(restTemplate.getForEntity("http://localhost:8080/tasks/2022-04-27T10:11Z", TaskDto.class)).thenReturn(ResponseEntity.of(Optional.of(taskDto)));
+        outputsToFtpService.exportOutputsForSuccessfulTasks(taskDto);
+        Mockito.verify(restTemplate, Mockito.times(1)).getForEntity("http://localhost:8080/tasks/2022-04-27T10:11Z/outputs", byte[].class);
+    }
+
+    @Test
+    void checkTaskManagerCallWithMissingFileForErrorTask() {
+        ReflectionTestUtils.setField(outputsToFtpService, "seperateOutputFiles", false);
+        TaskDto taskDto = new TaskDto(UUID.fromString("1fdda469-53e9-4d63-a533-b935cffdd2f6"), OffsetDateTime.parse("2022-04-27T10:11Z"), TaskStatus.ERROR, new ArrayList<>(), new ArrayList<>(), createProcessFileList(2, 1), new ArrayList<>());
+        Mockito.when(restTemplate.getForEntity("http://localhost:8080/tasks/2022-04-27T10:11Z/outputs", byte[].class)).thenReturn(ResponseEntity.ok("test".getBytes(StandardCharsets.UTF_8)));
+        Mockito.when(restTemplate.getForEntity("http://localhost:8080/tasks/2022-04-27T10:11Z", TaskDto.class)).thenReturn(ResponseEntity.of(Optional.of(taskDto)));
+        outputsToFtpService.exportOutputsForSuccessfulTasks(taskDto);
+        Mockito.verify(restTemplate, Mockito.times(1)).getForEntity("http://localhost:8080/tasks/2022-04-27T10:11Z/outputs", byte[].class);
+    }
+
+    @Test
+    void checkTaskManagerCallWithMissingFileForErrorTaskWithoutOutputs() {
+        TaskDto taskDto = new TaskDto(UUID.fromString("1fdda469-53e9-4d63-a533-b935cffdd2f6"), OffsetDateTime.parse("2022-04-27T10:11Z"), TaskStatus.ERROR, new ArrayList<>(), new ArrayList<>(), createProcessFileList(2, 0), new ArrayList<>());
         Mockito.when(restTemplate.getForEntity("http://localhost:8080/tasks/2022-04-27T10:11Z/outputs", byte[].class)).thenReturn(ResponseEntity.ok("test".getBytes(StandardCharsets.UTF_8)));
         Mockito.when(restTemplate.getForEntity("http://localhost:8080/tasks/2022-04-27T10:11Z", TaskDto.class)).thenReturn(ResponseEntity.of(Optional.of(taskDto)));
         outputsToFtpService.exportOutputsForSuccessfulTasks(taskDto);
@@ -69,7 +90,7 @@ class GridcapaExportServiceTest {
     }
 
     @Test
-    void checkTaskManagerCallForSeperateZipFiles() {
+    void checkTaskManagerCallForSeperateZipFilesForSuccessTask() {
         ReflectionTestUtils.setField(outputsToFtpService, "seperateOutputFiles", true);
         TaskDto taskDto = new TaskDto(UUID.fromString("1fdda469-53e9-4d63-a533-b935cffdd2f6"), OffsetDateTime.parse("2022-04-27T10:10Z"), TaskStatus.SUCCESS, new ArrayList<>(), new ArrayList<>(), createProcessFileList(3, 3), new ArrayList<>());
         Mockito.when(restTemplate.getForEntity("http://localhost:8080/tasks/2022-04-27T10:10Z/file/AA0", byte[].class)).thenReturn(ResponseEntity.ok("test1".getBytes(StandardCharsets.UTF_8)));
@@ -84,6 +105,26 @@ class GridcapaExportServiceTest {
         Mockito.verify(restTemplate, Mockito.atLeastOnce()).getForEntity("http://localhost:8080/tasks/2022-04-27T10:10Z/file/LOGS", byte[].class);
         try {
             Mockito.verify(ftpClientAdapter, Mockito.times(4)).upload(Mockito.anyString(), Mockito.any());
+        } catch (IOException e) {
+            Assertions.fail("checkTaskManagerCallForSeperateZipFiles : ftpClientAdapter should not throw IOException!");
+        }
+    }
+
+    @Test
+    void checkTaskManagerCallForSeperateZipFilesForInterruptedTask() {
+        ReflectionTestUtils.setField(outputsToFtpService, "seperateOutputFiles", true);
+        TaskDto taskDto = new TaskDto(UUID.fromString("1fdda469-53e9-4d63-a533-b935cffdd2f6"), OffsetDateTime.parse("2022-04-27T10:10Z"), TaskStatus.INTERRUPTED, new ArrayList<>(), new ArrayList<>(), createProcessFileList(3, 1), new ArrayList<>());
+        Mockito.when(restTemplate.getForEntity("http://localhost:8080/tasks/2022-04-27T10:10Z/file/AA0", byte[].class)).thenReturn(ResponseEntity.ok("test1".getBytes(StandardCharsets.UTF_8)));
+        Mockito.when(restTemplate.getForEntity("http://localhost:8080/tasks/2022-04-27T10:10Z/file/AA1", byte[].class)).thenReturn(ResponseEntity.ok("test2".getBytes(StandardCharsets.UTF_8)));
+        Mockito.when(restTemplate.getForEntity("http://localhost:8080/tasks/2022-04-27T10:10Z/file/AA2", byte[].class)).thenReturn(ResponseEntity.ok("test3".getBytes(StandardCharsets.UTF_8)));
+        Mockito.when(restTemplate.getForEntity("http://localhost:8080/tasks/2022-04-27T10:10Z/file/LOGS", byte[].class)).thenReturn(ResponseEntity.ok("rao-logs.zip".getBytes(StandardCharsets.UTF_8)));
+        Mockito.when(restTemplate.getForEntity("http://localhost:8080/tasks/2022-04-27T10:10Z", TaskDto.class)).thenReturn(ResponseEntity.of(Optional.of(taskDto)));
+        outputsToFtpService.exportOutputsForSuccessfulTasks(taskDto);
+        Mockito.verify(restTemplate, Mockito.atLeastOnce()).getForEntity("http://localhost:8080/tasks/2022-04-27T10:10Z/file/AA0", byte[].class);
+        Mockito.verify(restTemplate, Mockito.never()).getForEntity("http://localhost:8080/tasks/2022-04-27T10:10Z/file/AA1", byte[].class);
+        Mockito.verify(restTemplate, Mockito.atLeastOnce()).getForEntity("http://localhost:8080/tasks/2022-04-27T10:10Z/file/LOGS", byte[].class);
+        try {
+            Mockito.verify(ftpClientAdapter, Mockito.times(2)).upload(Mockito.anyString(), Mockito.any());
         } catch (IOException e) {
             Assertions.fail("checkTaskManagerCallForSeperateZipFiles : ftpClientAdapter should not throw IOException!");
         }

--- a/src/test/java/com/farao_community/farao/gridcapa/export/GridcapaExportServiceTest.java
+++ b/src/test/java/com/farao_community/farao/gridcapa/export/GridcapaExportServiceTest.java
@@ -92,11 +92,12 @@ class GridcapaExportServiceTest {
 
     @Test
     void checkTaskManagerCallWithMissingFileForErrorTaskWithoutOutputs() {
+        ReflectionTestUtils.setField(outputsToFtpService, "seperateOutputFiles", false);
         TaskDto taskDto = new TaskDto(UUID.fromString("1fdda469-53e9-4d63-a533-b935cffdd2f6"), OffsetDateTime.parse("2022-04-27T10:11Z"), TaskStatus.ERROR, new ArrayList<>(), new ArrayList<>(), createProcessFileList(2, 0), new ArrayList<>());
         Mockito.when(restTemplate.getForEntity("http://localhost:8080/tasks/2022-04-27T10:11Z/outputs", byte[].class)).thenReturn(ResponseEntity.ok("test".getBytes(StandardCharsets.UTF_8)));
         Mockito.when(restTemplate.getForEntity("http://localhost:8080/tasks/2022-04-27T10:11Z", TaskDto.class)).thenReturn(ResponseEntity.of(Optional.of(taskDto)));
         outputsToFtpService.exportOutputsForTask(taskDto);
-        Mockito.verify(restTemplate, Mockito.never()).getForEntity("http://localhost:8080/tasks/2022-04-27T10:11Z/outputs", byte[].class);
+        Mockito.verify(restTemplate, Mockito.times(1)).getForEntity("http://localhost:8080/tasks/2022-04-27T10:11Z/outputs", byte[].class);
     }
 
     @Test

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -2,7 +2,7 @@ spring:
   application:
     name: gridcapa-exporter
   rabbitmq:
-    host: rabbitmq
+    host: localhost
     port: 5672
     username: gridcapa
     password: gridcapa


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Feature

**What is the current behavior?** *(You can also link to an open issue here)*
Outputs and log file are exported only for success tasks


**What is the new behavior (if this is a feature change)?**
Exporting outputs files and log even if the status is error or some outputs are missing 




**Does this PR introduce a breaking change?** *(What changes might users need to make in their application due to this PR?)*



**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
